### PR TITLE
feat(runtime): published the lenient call api

### DIFF
--- a/runtime/src/main/kotlin/Annotations.kt
+++ b/runtime/src/main/kotlin/Annotations.kt
@@ -1,0 +1,27 @@
+/*
+ *	Copyright 2023 cufy.org and meemer.com
+ *
+ *	Licensed under the Apache License, Version 2.0 (the "License");
+ *	you may not use this file except in compliance with the License.
+ *	You may obtain a copy of the License at
+ *
+ *	    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *	Unless required by applicable law or agreed to in writing, software
+ *	distributed under the License is distributed on an "AS IS" BASIS,
+ *	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *	See the License for the specific language governing permissions and
+ *	limitations under the License.
+ */
+package org.cufy.ranno
+
+/**
+ * Marks the annotated component as experimental.
+ *
+ * @since 1.0.0
+ */
+@RequiresOptIn(
+    message = "This is an experimental API and might change at anytime",
+    level = RequiresOptIn.Level.WARNING
+)
+annotation class ExperimentalRannoApi

--- a/runtime/src/main/kotlin/Ranno.kt
+++ b/runtime/src/main/kotlin/Ranno.kt
@@ -15,12 +15,12 @@
  */
 package org.cufy.ranno
 
-import org.cufy.ranno.internal.callSuspendWithOrLess
-import org.cufy.ranno.internal.callWithOrLess
-import org.cufy.ranno.internal.canCallWith
+import org.cufy.ranno.internal.*
 import org.cufy.ranno.internal.enumerateElementsWith
 import kotlin.reflect.*
+import kotlin.reflect.full.callSuspend
 import kotlin.reflect.full.findAnnotations
+import kotlin.reflect.jvm.jvmErasure
 
 //////////////////////////////////////////////////
 
@@ -210,7 +210,7 @@ inline fun <reified T : Annotation> elementsWith(predicate: (T) -> Boolean = { t
  * @since 1.0.0
  */
 fun elementsWith(annotation: Annotation): List<KAnnotatedElement> {
-    return elementsWith(annotation::class).filter { it.annotations.contains(annotation) }
+    return elementsWith(annotation::class).filter { annotation in it.annotations }
 }
 
 //////////////////////////////////////////////////
@@ -378,16 +378,16 @@ fun classesWith(annotation: Annotation): List<KClass<*>> {
 //////////////////////////////////////////////////
 
 /**
- * Call the functions and properties annotated with [annotation] qualified name
+ * Call the functions annotated with [annotation] qualified name
  * and matches the given [predicate]
  * with the given [arguments].
  *
  * __Note: Suspend functions won't be run with this
- * function event if a continuation is passed as the
+ * function even if a continuation is passed as the
  * last argument. To also invoke suspending functions
  * use [runWithSuspend].__
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -397,21 +397,27 @@ fun classesWith(annotation: Annotation): List<KClass<*>> {
  * @param arguments the arguments.
  * @since 1.0.0
  */
-fun runWith(annotation: String, vararg arguments: Any?, predicate: (KCallable<*>) -> Boolean = { true }): List<Any?> {
-    return elementsWith(annotation).mapMaybeInvoke(arguments, predicate)
+fun runWith(annotation: String, vararg arguments: Any?, predicate: (KFunction<*>) -> Boolean = { true }): List<Any?> {
+    @OptIn(ExperimentalRannoApi::class)
+    return elementsWith(annotation)
+        .asSequence()
+        .filterIsInstance<KFunction<*>>()
+        .filter { it.canCallWith(*arguments) && predicate(it) }
+        .map { it.callWith(*arguments) }
+        .toList()
 }
 
 /**
- * Call the functions and properties annotated with [annotation]
+ * Call the functions annotated with [annotation]
  * and matches the given [predicate]
  * with the given [arguments].
  *
  * __Note: Suspend functions won't be run with this
- * function event if a continuation is passed as the
+ * function even if a continuation is passed as the
  * last argument. To also invoke suspending functions
  * use [runWithSuspend].__
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -421,21 +427,27 @@ fun runWith(annotation: String, vararg arguments: Any?, predicate: (KCallable<*>
  * @param arguments the arguments.
  * @since 1.0.0
  */
-fun runWith(annotation: KClass<out Annotation>, vararg arguments: Any?, predicate: (KCallable<*>) -> Boolean = { true }): List<Any?> {
-    return elementsWith(annotation).mapMaybeInvoke(arguments, predicate)
+fun runWith(annotation: KClass<out Annotation>, vararg arguments: Any?, predicate: (KFunction<*>) -> Boolean = { true }): List<Any?> {
+    @OptIn(ExperimentalRannoApi::class)
+    return elementsWith(annotation)
+        .asSequence()
+        .filterIsInstance<KFunction<*>>()
+        .filter { it.canCallWith(*arguments) && predicate(it) }
+        .map { it.callWith(*arguments) }
+        .toList()
 }
 
 /**
- * Call the functions and properties annotated with [T]
+ * Call the functions annotated with [T]
  * and matches the given [predicate]
  * with the given [arguments].
  *
  * __Note: Suspend functions won't be run with this
- * function event if a continuation is passed as the
+ * function even if a continuation is passed as the
  * last argument. To also invoke suspending functions
  * use [runWithSuspend].__
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -450,15 +462,15 @@ inline fun <reified T : Annotation> runWith(vararg arguments: Any?, noinline pre
 }
 
 /**
- * Call the functions and properties annotated with [annotation]
+ * Call the functions annotated with [annotation]
  * with the given [arguments].
  *
  * __Note: Suspend functions won't be run with this
- * function event if a continuation is passed as the
+ * function even if a continuation is passed as the
  * last argument. To also invoke suspending functions
  * use [runWithSuspend].__
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -469,17 +481,17 @@ inline fun <reified T : Annotation> runWith(vararg arguments: Any?, noinline pre
  * @since 1.0.0
  */
 fun runWith(annotation: Annotation, vararg arguments: Any?): List<Any?> {
-    return elementsWith(annotation).mapMaybeInvoke(arguments)
+    return runWith(annotation::class, *arguments) { annotation in it.annotations }
 }
 
 //////////////////////////////////////////////////
 
 /**
- * Call the functions and properties annotated with [annotation] qualified name
+ * Call the functions annotated with [annotation] qualified name
  * and matches the given [predicate]
  * with the given [arguments].
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -489,16 +501,21 @@ fun runWith(annotation: Annotation, vararg arguments: Any?): List<Any?> {
  * @param arguments the arguments.
  * @since 1.0.0
  */
-suspend fun runWithSuspend(annotation: String, vararg arguments: Any?, predicate: (KCallable<*>) -> Boolean = { true }): List<Any?> {
-    return elementsWith(annotation).mapMaybeInvokeSuspend(arguments, predicate)
+suspend fun runWithSuspend(annotation: String, vararg arguments: Any?, predicate: (KFunction<*>) -> Boolean = { true }): List<Any?> {
+    @OptIn(ExperimentalRannoApi::class)
+    return elementsWith(annotation)
+        .asSequence()
+        .filterIsInstance<KFunction<*>>()
+        .filter { it.canCallWithSuspend(*arguments) && predicate(it) }
+        .mapTo(mutableListOf()) { it.callWithSuspend(*arguments) }
 }
 
 /**
- * Call the functions and properties annotated with [annotation]
+ * Call the functions annotated with [annotation]
  * and matches the given [predicate]
  * with the given [arguments].
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -508,16 +525,21 @@ suspend fun runWithSuspend(annotation: String, vararg arguments: Any?, predicate
  * @param arguments the arguments.
  * @since 1.0.0
  */
-suspend fun runWithSuspend(annotation: KClass<out Annotation>, vararg arguments: Any?, predicate: (KCallable<*>) -> Boolean = { true }): List<Any?> {
-    return elementsWith(annotation).mapMaybeInvokeSuspend(arguments, predicate)
+suspend fun runWithSuspend(annotation: KClass<out Annotation>, vararg arguments: Any?, predicate: (KFunction<*>) -> Boolean = { true }): List<Any?> {
+    @OptIn(ExperimentalRannoApi::class)
+    return elementsWith(annotation)
+        .asSequence()
+        .filterIsInstance<KFunction<*>>()
+        .filter { it.canCallWithSuspend(*arguments) && predicate(it) }
+        .mapTo(mutableListOf()) { it.callWithSuspend(*arguments) }
 }
 
 /**
- * Call the functions and properties annotated with [T]
+ * Call the functions annotated with [T]
  * and matches the given [predicate]
  * with the given [arguments].
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -532,10 +554,10 @@ suspend inline fun <reified T : Annotation> runWithSuspend(vararg arguments: Any
 }
 
 /**
- * Call the functions and properties annotated with [annotation]
+ * Call the functions annotated with [annotation]
  * with the given [arguments].
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -546,22 +568,22 @@ suspend inline fun <reified T : Annotation> runWithSuspend(vararg arguments: Any
  * @since 1.0.0
  */
 suspend fun runWithSuspend(annotation: Annotation, vararg arguments: Any?): List<Any?> {
-    return elementsWith(annotation).mapMaybeInvokeSuspend(arguments)
+    return runWithSuspend(annotation::class, *arguments) { annotation in it.annotations }
 }
 
 //////////////////////////////////////////////////
 
 /**
- * Call the functions and properties annotated with [annotation]
+ * Call the functions annotated with [annotation]
  * and matches the given [predicate]
  * with [this] as the argument.
  *
  * __Note: Suspend functions won't be run with this
- * function event if a continuation is passed as the
+ * function even if a continuation is passed as the
  * last argument. To also invoke suspending functions
  * use [applyWithSuspend].__
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -571,21 +593,21 @@ suspend fun runWithSuspend(annotation: Annotation, vararg arguments: Any?): List
  * @param arguments additional arguments.
  * @since 1.0.0
  */
-fun Any.applyWith(annotation: String, vararg arguments: Any?, predicate: (KCallable<*>) -> Boolean = { true }): List<Any?> {
+fun Any.applyWith(annotation: String, vararg arguments: Any?, predicate: (KFunction<*>) -> Boolean = { true }): List<Any?> {
     return runWith(annotation, this, *arguments, predicate = predicate)
 }
 
 /**
- * Call the functions and properties annotated with [annotation]
+ * Call the functions annotated with [annotation]
  * and matches the given [predicate]
  * with [this] as the argument.
  *
  * __Note: Suspend functions won't be run with this
- * function event if a continuation is passed as the
+ * function even if a continuation is passed as the
  * last argument. To also invoke suspending functions
  * use [applyWithSuspend].__
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -595,21 +617,21 @@ fun Any.applyWith(annotation: String, vararg arguments: Any?, predicate: (KCalla
  * @param arguments additional arguments.
  * @since 1.0.0
  */
-fun Any.applyWith(annotation: KClass<out Annotation>, vararg arguments: Any?, predicate: (KCallable<*>) -> Boolean = { true }): List<Any?> {
+fun Any.applyWith(annotation: KClass<out Annotation>, vararg arguments: Any?, predicate: (KFunction<*>) -> Boolean = { true }): List<Any?> {
     return runWith(annotation, this, *arguments, predicate = predicate)
 }
 
 /**
- * Call all the functions and properties annotated with [T]
+ * Call all the functions annotated with [T]
  * and matches the given [predicate]
  * with [this] as the argument.
  *
  * __Note: Suspend functions won't be run with this
- * function event if a continuation is passed as the
+ * function even if a continuation is passed as the
  * last argument. To also invoke suspending functions
  * use [applyWithSuspend].__
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -620,19 +642,19 @@ fun Any.applyWith(annotation: KClass<out Annotation>, vararg arguments: Any?, pr
  * @since 1.0.0
  */
 inline fun <reified T : Annotation> Any.applyWith(vararg arguments: Any?, noinline predicate: (T) -> Boolean = { true }): List<Any?> {
-    return applyWith(T::class, *arguments) { it.findAnnotations<T>().any(predicate) }
+    return runWith<T>(this, *arguments, predicate = predicate)
 }
 
 /**
- * Call the functions and properties annotated with [annotation]
+ * Call the functions annotated with [annotation]
  * with [this] as the argument.
  *
  * __Note: Suspend functions won't be run with this
- * function event if a continuation is passed as the
+ * function even if a continuation is passed as the
  * last argument. To also invoke suspending functions
  * use [applyWithSuspend].__
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -649,11 +671,11 @@ fun Any.applyWith(annotation: Annotation, vararg arguments: Any?): List<Any?> {
 //////////////////////////////////////////////////
 
 /**
- * Call the functions and properties annotated with [annotation]
+ * Call the functions annotated with [annotation]
  * and matches the given [predicate]
  * with [this] as the argument.
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -663,16 +685,16 @@ fun Any.applyWith(annotation: Annotation, vararg arguments: Any?): List<Any?> {
  * @param arguments additional arguments.
  * @since 1.0.0
  */
-suspend fun Any.applyWithSuspend(annotation: String, vararg arguments: Any?, predicate: (KCallable<*>) -> Boolean = { true }): List<Any?> {
+suspend fun Any.applyWithSuspend(annotation: String, vararg arguments: Any?, predicate: (KFunction<*>) -> Boolean = { true }): List<Any?> {
     return runWithSuspend(annotation, this, *arguments, predicate = predicate)
 }
 
 /**
- * Call the functions and properties annotated with [annotation]
+ * Call the functions annotated with [annotation]
  * and matches the given [predicate]
  * with [this] as the argument.
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -682,16 +704,16 @@ suspend fun Any.applyWithSuspend(annotation: String, vararg arguments: Any?, pre
  * @param arguments additional arguments.
  * @since 1.0.0
  */
-suspend fun Any.applyWithSuspend(annotation: KClass<out Annotation>, vararg arguments: Any?, predicate: (KCallable<*>) -> Boolean = { true }): List<Any?> {
+suspend fun Any.applyWithSuspend(annotation: KClass<out Annotation>, vararg arguments: Any?, predicate: (KFunction<*>) -> Boolean = { true }): List<Any?> {
     return runWithSuspend(annotation, this, *arguments, predicate = predicate)
 }
 
 /**
- * Call all the functions and properties annotated with [T]
+ * Call all the functions annotated with [T]
  * and matches the given [predicate]
  * with [this] as the argument.
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -702,14 +724,14 @@ suspend fun Any.applyWithSuspend(annotation: KClass<out Annotation>, vararg argu
  * @since 1.0.0
  */
 suspend inline fun <reified T : Annotation> Any.applyWithSuspend(vararg arguments: Any?, noinline predicate: (T) -> Boolean = { true }): List<Any?> {
-    return applyWithSuspend(T::class, *arguments) { it.findAnnotations<T>().any(predicate) }
+    return runWithSuspend<T>(this, *arguments, predicate = predicate)
 }
 
 /**
- * Call the functions and properties annotated with [annotation]
+ * Call the functions annotated with [annotation]
  * with [this] as the argument.
  *
- * Only functions and properties that can be invoked with the
+ * Only functions that can be invoked with the
  * provided arguments will be invoked.
  *
  * ___Note: Only the elements passed to ranno
@@ -812,23 +834,77 @@ annotation class EnumerationOnly
 
 //////////////////////////////////////////////////
 
-private inline fun Iterable<KAnnotatedElement>.mapMaybeInvoke(
-    arguments: Array<out Any?>,
-    crossinline predicate: (KCallable<*>) -> Boolean = { true }
-): List<Any?> {
-    return asSequence()
-        .filterIsInstance<KCallable<*>>()
-        .filter { !it.isSuspend && it.canCallWith(*arguments) && predicate(it) }
-        .map { it.callWithOrLess(*arguments) }
-        .toList()
+/**
+ * Return true if this callable can be call with the given [arguments].
+ *
+ * If the callable accepts fewer arguments,
+ * the extra arguments are ignored.
+ *
+ * @since 1.0.0
+ */
+@ExperimentalRannoApi
+fun KFunction<*>.canCallWith(vararg arguments: Any?): Boolean {
+    return !isSuspend && canCallWithSuspend(*arguments)
 }
 
-private suspend inline fun Iterable<KAnnotatedElement>.mapMaybeInvokeSuspend(
-    arguments: Array<out Any?>,
-    crossinline predicate: (KCallable<*>) -> Boolean = { true }
-): List<Any?> {
-    return asSequence()
-        .filterIsInstance<KCallable<*>>()
-        .filter { it.canCallWith(*arguments) && predicate(it) }
-        .mapTo(mutableListOf()) { it.callSuspendWithOrLess(*arguments) }
+/**
+ * Call this callable with the given [arguments].
+ *
+ * If the callable accepts fewer arguments,
+ * the extra arguments are ignored.
+ *
+ * @return the returned value.
+ * @since 1.0.0
+ */
+@ExperimentalRannoApi
+fun KFunction<*>.callWith(vararg arguments: Any?): Any? {
+    trySetAccessibleAlternative()
+
+    return if (parameters.size == arguments.size)
+        call(*arguments)
+    else
+        call(*arguments.take(parameters.size).toTypedArray())
+}
+
+/**
+ * Return true if this callable can be call with the given [arguments].
+ *
+ * If the callable accepts fewer arguments,
+ * the extra arguments are ignored.
+ *
+ * @since 1.0.0
+ */
+@ExperimentalRannoApi
+fun KFunction<*>.canCallWithSuspend(vararg arguments: Any?): Boolean {
+    if (parameters.size > arguments.size)
+        return false
+
+    for (i in parameters.indices) {
+        val parameter = parameters[i]
+        val argument = arguments[i]
+
+        if (!parameter.type.jvmErasure.isInstance(argument))
+            return false
+    }
+
+    return true
+}
+
+/**
+ * Call this callable with the given [arguments].
+ *
+ * If the callable accepts fewer arguments,
+ * the extra arguments are ignored.
+ *
+ * @return the returned value.
+ * @since 1.0.0
+ */
+@ExperimentalRannoApi
+suspend fun KFunction<*>.callWithSuspend(vararg arguments: Any?): Any? {
+    trySetAccessibleAlternative()
+
+    return if (parameters.size == arguments.size)
+        callSuspend(*arguments)
+    else
+        callSuspend(*arguments.take(parameters.size).toTypedArray())
 }

--- a/runtime/src/main/kotlin/internal/lookup_toplevel.kt
+++ b/runtime/src/main/kotlin/internal/lookup_toplevel.kt
@@ -152,10 +152,12 @@ private fun unsupported(): Nothing {
     )
 }
 
-private fun <T> Method.asToplevelKFunction() = ToplevelKFunction<T>(this)
+internal fun <T> Method.asToplevelKFunction() = ToplevelKFunction<T>(this)
 
 /** a custom implementation of [KFunction] for toplevel property accessor */
-private class ToplevelKFunction<T>(private val method: Method) : KFunction<T> {
+internal class ToplevelKFunction<T>(
+    val method: Method
+) : KFunction<T> {
     override val isSuspend get() = false
     override val isFinal get() = true
     override val isOpen get() = false
@@ -220,11 +222,11 @@ private class ToplevelKFunction<T>(private val method: Method) : KFunction<T> {
 }
 
 /** a custom implementation of [KProperty0] for toplevel property */
-private open class ToplevelKProperty0<V>(
+internal open class ToplevelKProperty0<V>(
     override val name: String,
     override val annotations: List<Annotation>,
-    private val get: KFunction<V>,
-    private val delegate: Lazy<Any?>
+    val get: KFunction<V>,
+    val delegate: Lazy<Any?>
 ) : KProperty0<V>, KCallable<V> by get {
     override val isSuspend get() = false
     override val isFinal get() = true
@@ -253,11 +255,11 @@ private open class ToplevelKProperty0<V>(
 }
 
 /** a custom implementation of [KMutableProperty0] for toplevel property */
-private open class ToplevelKMutableProperty0<V>(
+internal open class ToplevelKMutableProperty0<V>(
     name: String,
     annotations: List<Annotation>,
     get: KFunction<V>,
-    private val set: KFunction<Unit>,
+    val set: KFunction<Unit>,
     delegate: Lazy<Any?>
 ) : ToplevelKProperty0<V>(name, annotations, get, delegate), KMutableProperty0<V> {
     override val setter: KMutableProperty0.Setter<V> by lazy {
@@ -276,11 +278,11 @@ private open class ToplevelKMutableProperty0<V>(
 }
 
 /** a custom implementation of [KProperty1] for toplevel property */
-private open class ToplevelKProperty1<out V>(
+internal open class ToplevelKProperty1<out V>(
     override val name: String,
     override val annotations: List<Annotation>,
-    private val get: KFunction<V>,
-    private val delegate: Lazy<Any?>
+    val get: KFunction<V>,
+    val delegate: Lazy<Any?>
 ) : KProperty1<Any?, V>, KCallable<V> by get {
     override val isSuspend get() = false
     override val isFinal get() = true
@@ -309,11 +311,11 @@ private open class ToplevelKProperty1<out V>(
 }
 
 /** a custom implementation of [KMutableProperty1] for toplevel property */
-private open class ToplevelKMutableProperty1<V>(
+internal open class ToplevelKMutableProperty1<V>(
     name: String,
     annotations: List<Annotation>,
     get: KFunction<V>,
-    private val set: KFunction<Unit>,
+    val set: KFunction<Unit>,
     delegate: Lazy<Any?>
 ) : ToplevelKProperty1<V>(name, annotations, get, delegate), KCallable<V>, KMutableProperty1<Any?, V> {
     override val setter: KMutableProperty1.Setter<Any?, V> by lazy {


### PR DESCRIPTION
feat: callWith extension functions for `KFunction<*>`
chore: added ExperimentalRannoApi
breaking: runWith and its overloads no longer supports properties
fix: function accessibility for private function invocations