### PR TITLE
fix(runtime): internal: issues accessing resources

### DIFF
--- a/ranno-runtime/src/main/kotlin/internal/URI_list.kt
+++ b/ranno-runtime/src/main/kotlin/internal/URI_list.kt
@@ -1,0 +1,66 @@
+package org.cufy.ranno.internal
+
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.spi.FileSystemProvider
+import java.util.jar.JarFile
+import kotlin.streams.asSequence
+
+internal fun URI.listUrisOrEmpty(): List<URI> {
+    return listOrEmpty().map { createSubUri(this, it) }
+}
+
+internal fun URI.listOrEmpty(): List<String> {
+    @Suppress("IntroduceWhenSubject")
+    return when {
+        scheme == "jar" -> jar_listOrEmpty()
+        scheme == "file" -> file_listOrEmpty()
+        else -> emptyList()
+    }
+}
+
+@Suppress("FunctionName")
+private fun URI.jar_listOrEmpty(): List<String> {
+    require(scheme == "jar")
+
+    val pathname = this.toString()
+        .removePrefix("jar:")
+        .removePrefix("file:")
+
+    // if jar file system is supported (aka ZipFileSystemProvider is present)
+    if (FileSystemProvider.installedProviders().any { it.scheme == "jar" }) {
+        return useFilesystem { filesystem ->
+            val relativePathname = pathname.substringAfter("!")
+            val resourcePath = filesystem.getPath(relativePathname)
+            Files.walk(resourcePath, 1)
+                .asSequence()
+                .drop(1)
+                .map { it.fileName.toString() }
+                .toList()
+        }
+    }
+
+    // Second approach
+    // Inspiration: https://github.com/kherge/java.resource/blob/master/src/main/java/io/herrera/kevin/resource/Resource.java
+    val physicalPathname = pathname.substringBefore("!/")
+    val folder = pathname.substringAfter("!/")
+        .let { if (it.endsWith("/")) it else "$it/" }
+
+    val resourceFile = JarFile(physicalPathname)
+
+    return resourceFile.use {
+        // stream all the files in the jar (java streams API)
+        it.stream()
+            // name length check is a lighter way for excluding the folder itself from the results
+            .filter { it.name.length > folder.length && it.name.startsWith(folder) }
+            // transform, stripping the folder name to end up with just the last segment of the path
+            .map { it.name.removePrefix(folder) }
+            .toList()
+    }
+}
+
+@Suppress("FunctionName")
+private fun URI.file_listOrEmpty(): List<String> {
+    require(scheme == "file")
+    return readLinesOrEmpty().toList()
+}

--- a/ranno-runtime/src/main/kotlin/internal/enumerate.kt
+++ b/ranno-runtime/src/main/kotlin/internal/enumerate.kt
@@ -29,9 +29,9 @@ internal fun enumerateElementsWith(annotation: String): List<KAnnotatedElement> 
     return elementCache.getOrPut(annotation) {
         listResourceLocations("$ANNOTATION_QN/$annotation")
             .asSequence() // -> list of directories uris
-            .flatMap { it.listUris() } // -> list of files uris
+            .flatMap { it.listUrisOrEmpty() } // -> list of files uris
             .distinct()
-            .flatMap { it.readLines() } // -> list of lines
+            .flatMap { it.readLinesOrEmpty() } // -> list of lines
             .mapNotNull {
                 lookupElement(it) ?: run {
                     logger.warning { "Element not found at runtime: $it" }

--- a/ranno-runtime/src/main/kotlin/internal/listResourceLocations.kt
+++ b/ranno-runtime/src/main/kotlin/internal/listResourceLocations.kt
@@ -1,0 +1,53 @@
+package org.cufy.ranno.internal
+
+import org.cufy.ranno.Enumerable
+import org.cufy.ranno.Enumerated
+import java.net.URI
+
+/**
+ * Get all the locations of the resource with the
+ * given [name].
+ */
+internal fun listResourceLocations(name: String): List<URI> {
+    return buildList {
+        addAll(listUsingSystemClassLoader(name))
+        addAll(listUsingRannoClassLoader(name))
+        addAll(listUsingBruteforceAOSP(name))
+    }
+}
+
+private fun listUsingSystemClassLoader(name: String): List<URI> {
+    return ClassLoader.getSystemResources(name)
+        .asSequence()
+        .map { it.toURI() }
+        .toList()
+}
+
+private fun listUsingRannoClassLoader(name: String): List<URI> {
+    return Enumerable::class.java.classLoader
+        ?.getResources(name)
+        ?.asSequence()
+        .orEmpty()
+        .map { it.toURI() }
+        .toList()
+}
+
+/**
+ * Special treatment just for AOSP (android), for some reason,
+ * android is incapable of locating the location of a directory.
+ * Thus, this approach trys (or return an empty list on failure)
+ * to locate the location of a file that is sure to exist at runtime
+ * and then locate the directory by searching relative to it.
+ */
+private fun listUsingBruteforceAOSP(name: String): List<URI> {
+    val rootPathname = Enumerated::class.java.classLoader
+        ?.getResource("AndroidManifest.xml")
+        ?.toURI()
+        ?.toString()
+        ?.removeSuffix("AndroidManifest.xml")
+        ?.removeSuffix("/")
+
+    rootPathname ?: return emptyList()
+
+    return listOf(URI("$rootPathname/$name"))
+}

--- a/ranno-runtime/src/main/kotlin/internal/resources.kt
+++ b/ranno-runtime/src/main/kotlin/internal/resources.kt
@@ -19,8 +19,6 @@ import java.net.URI
 import java.nio.file.FileSystem
 import java.nio.file.FileSystemNotFoundException
 import java.nio.file.FileSystems
-import java.nio.file.Files
-import kotlin.streams.asSequence
 
 /*
 Notes on java resources:
@@ -30,51 +28,15 @@ Notes on java resources:
 */
 
 /**
- * Get all the locations of the resource with the
- * given [name].
+ * Try reading the lines in this uri, or return an empty
+ * sequence on failure.
  */
-internal fun listResourceLocations(name: String): List<URI> {
-    return ClassLoader.getSystemResources(name).asSequence().map { it.toURI() }.toList()
-}
-
-internal fun createSubUri(parent: URI, child: String): URI {
-    val parentString = parent.toString().removeSuffix("/")
-    return URI.create("$parentString/$child")
-}
-
-internal fun URI.listUris(): List<URI> {
-    return list().map { createSubUri(this, it) }
-}
-
-internal fun URI.list(): List<String> {
-    @Suppress("IntroduceWhenSubject")
-    return when {
-        scheme == "jar" -> jarList()
-        scheme == "file" -> fileList()
-        else -> emptyList()
+internal fun URI.readLinesOrEmpty(): Sequence<String> {
+    return try {
+        toURL().openStream().reader().readLines().asSequence()
+    } catch (e: Exception) {
+        emptySequence()
     }
-}
-
-private fun URI.jarList(): List<String> {
-    require(scheme == "jar")
-    return useFilesystem { filesystem ->
-        val path = toString().substringAfter("!")
-        val resourcePath = filesystem.getPath(path)
-        Files.walk(resourcePath, 1)
-            .asSequence()
-            .drop(1)
-            .map { it.fileName.toString() }
-            .toList()
-    }
-}
-
-private fun URI.fileList(): List<String> {
-    require(scheme == "file")
-    return readLines().toList()
-}
-
-internal fun URI.readLines(): Sequence<String> {
-    return toURL().openStream().reader().readLines().asSequence()
 }
 
 internal fun <T> URI.useFilesystem(block: (FileSystem) -> T): T {
@@ -87,4 +49,9 @@ internal fun <T> URI.useFilesystem(block: (FileSystem) -> T): T {
         val filesystem = FileSystems.newFileSystem(this, mutableMapOf<String?, Any?>())
         filesystem.use(block)
     }
+}
+
+internal fun createSubUri(parent: URI, child: String): URI {
+    val parentString = parent.toString().removeSuffix("/")
+    return URI.create("$parentString/$child")
 }


### PR DESCRIPTION
Fixes issues when accessing resources in compose desktop and AOSP to grab the signatures of annotated elements.

Comment:

Although the JVM is a revolutionary concept,
implementations of JRE and the different
environments and setups can cause some features
to be absolutely missed up.

In this fix, I tried to savage all information
and details about these setups and here is a brief of the problems I solved in this commit.

android: AOSP does not implement resource directory
  locating when using ClassLoader.getResources() or
  any similar functions. This is a huge problem for
  ranno since it depends on enumerating the items of
  a specific resource directory for it to read the
  signatures of annotated elements.

compose-desktop: when using the createDistributable gradle
  task, the output includes an embed jre that has some
  functionality missing, in my case, the functionality was
  ZipFileSystemProvider which was necessary for enumerating
  items in a directory which is a deal-breaker for ranno.

finally, the solutions that was implemented are not THE solution for the original problem (jvm resources is not unified experience) and future issues might come. Additionally, the solutions here are actually workarounds that satisfies the needs of ranno and highly doubt will work on any other library or needs.